### PR TITLE
Parse HTTP requests from browser with TCPServer

### DIFF
--- a/challenge_3/http.rb
+++ b/challenge_3/http.rb
@@ -11,28 +11,28 @@ loop do
   puts "Got a new client!"
   
   # Read the request line
-  # Do I need the chomp? Seems to work fine without it
+  # Chomp is not strictly needed given our use of String#split (which discards
+  # the CLRF for us automatically), but it's nice to encapsulate the reading
+  # of this request line into a single line of code that ensures it is cleaned
+  # up appropriately (no surprises later on!)
   request_line = client.readline.chomp
-  request_line_split = request_line.split(' ')
-
   puts "Parsing HTTP request!"
+  method, target, http_version = request_line.split
 
   puts "\n"
   puts "-" * 90
   puts "\n"
 
-  puts "Request method: #{request_line_split[0]}"
-  puts "Request target: #{request_line_split[1]}"
-  puts "HTTP Version: #{request_line_split[2]}"
+  puts "Request method: #{method}"
+  puts "Request target: #{target}"
+  puts "HTTP Version: #{http_version}"
 
-  puts "\n"
-  puts "-" * 90
-  puts "\n"
+  client.close
 
   # Read the rest of the HTTP message
-  # Are these all headers?
-  puts "Getting rest of HTTP message"
-  while !client.eof?
-    puts client.readline
-  end
+  # The rest is all headers
+  # We'll ignore this for now since we just want the request line
+  # while !client.eof?
+  #   puts client.readline
+  # end
 end

--- a/challenge_3/http.rb
+++ b/challenge_3/http.rb
@@ -1,0 +1,38 @@
+require 'socket'
+
+server = TCPServer.new 1234
+
+# "A request is what a browser will send to your application when you visit a
+#   URL like http://localhost:1234/my/awesome/path."
+
+loop do
+  # Accept a client connection
+  client = server.accept
+  puts "Got a new client!"
+  
+  # Read the request line
+  # Do I need the chomp? Seems to work fine without it
+  request_line = client.readline.chomp
+  request_line_split = request_line.split(' ')
+
+  puts "Parsing HTTP request!"
+
+  puts "\n"
+  puts "-" * 90
+  puts "\n"
+
+  puts "Request method: #{request_line_split[0]}"
+  puts "Request target: #{request_line_split[1]}"
+  puts "HTTP Version: #{request_line_split[2]}"
+
+  puts "\n"
+  puts "-" * 90
+  puts "\n"
+
+  # Read the rest of the HTTP message
+  # Are these all headers?
+  puts "Getting rest of HTTP message"
+  while !client.eof?
+    puts client.readline
+  end
+end


### PR DESCRIPTION
```
Challenge: Modify your Ruby program so that it can accept HTTP requests and print out (on the console) 
the request method, request target and HTTP version of each request
```

## Key Learnings
- HTTP is a protocol that allows web browsers to talk to web applications
- HTTP is built on top of the TCP protocol (which is built on top of IP). Remember, TCP is application agnostic!
- HTTP communication comes in the form of **messages**
- Messages have the following structure:
     - a start line; then
     - zero or more header fields; then
     - a blank line; and finally
     - an optional message body.
- A `start line` is either a `request-line` (request from browser / client to server) or a `status-line` (response from server to client)
- Request lines follow the following format: begins with a method token, followed by a single space (SP), the request-target, another single space (SP), the protocol version, and ends with CRLF (carriage return line feed - TLDR from Tom, thsi comes from the typewriter days).
- Our program will only parse `GET` requests for now, which are used to fetch a particular path from the app
     - Path = string
     - App has to decide what the string actually means 


## Changes from Challenge 1
- We get the first line from the client, chomp it to get rid of the CRLF
- We split it on the whitespace delimiter to get the three parts of the request line: 
     * a method token which specifies what kind of request is being made;
     * a request target which identifies what path is being requested; and
     * the version number of the HTTP protocol being used.
- We print out the parts of the request line
- We read the rest of the HTTP message (I'm assuming it's all headers)

## Questions for Tom
- I'm assuming this new program only conforms to HTTP protocol - do I need to add some conditional logic to print out the details of the HTTP start line, _only_ if we're receiving an HTTP message? Can an application follow more than one protocol? Is there a more definitive way to define what kind of protocol an application is conforming to?
- Is the `chomp` on the readline necessary? I saw the resource for this method and assumed I needed to use it somewhere 😆 
- Can `GET` requests send a message body? Or do the methods that only fetch resources (get, head, etc.) not have them?
    - If this is possible, can we get the browser to do it with our request? 
- I'm assuming the remainder of the message is the headers... Are these fixed? (ie. would we see these same set of headers across most GET requests?) Are they browser-specific at all?