### PR TITLE
Challenge 5- introducing HTML responses

### DIFF
--- a/challenge_5/html_response.rb
+++ b/challenge_5/html_response.rb
@@ -1,8 +1,9 @@
+### Require dependencies
 require 'socket'
 require 'cgi'
 
-server = TCPServer.new 1234
-
+### Define some constants ###
+#############################
 # More info here: https://tools.ietf.org/html/rfc7231#section-6
 STATUS_CODES = {
   ok: 200
@@ -15,18 +16,22 @@ STATUS_CODES_TEXT = {
 
 HTTP_VERSION = 'HTTP/1.1'
 
-def data
-  [
-    {
-      title: 'My awesome blog!',
-      content: 'my favourite HTML tags are <p> and <script>'
-    },
-    {
-      title: 'Another cool blog!',
-      content: 'my favourite HTML tags are <br> and <hr>'
-    }
-  ]
-end
+BLOG_DATA = 
+[
+  {
+    title: 'My awesome blog!',
+    content: 'my favourite HTML tags are <p> and <script>'
+  },
+  {
+    title: 'Another cool blog!',
+    content: 'my favourite HTML tags are <br> and <hr>'
+  }
+]
+
+CRLF = "\r\n"
+#############################
+
+server = TCPServer.new 1234
 
 loop do
   # Accept a client connection
@@ -39,7 +44,7 @@ loop do
   method, target, http_version = request_line.split
 
   puts "Building response for client!"
-  status_line = "#{HTTP_VERSION} #{STATUS_CODES[:ok]} #{STATUS_CODES_TEXT[:ok]}\r\n"
+  status_line = "#{HTTP_VERSION} #{STATUS_CODES[:ok]} #{STATUS_CODES_TEXT[:ok]}"
 
   # Check request target to determine what to render for message body / headers
   if target == '/show-data'
@@ -47,7 +52,7 @@ loop do
     header_field = "Content-Type: text/html\r\n"
     message_body = ""
     message_body << "<ul>"
-    data.each do |element|
+    BLOG_DATA.each do |element|
       message_body << "<li>"
       message_body << "<strong>Title: #{CGI.escape_html(element[:title])}</strong>, Content: #{CGI.escape_html(element[:content])}"
       message_body << "</li>"
@@ -59,10 +64,10 @@ loop do
   end
 
   # Send response to client
-  client.write(status_line)
-  client.write(header_field)
+  client.write(status_line + CRLF)
+  client.write(header_field + CRLF)
   # CRLF to separate the headers from the message body
-  client.write("\r\n")
+  client.write(CRLF)
   client.write(message_body)
 
   client.close

--- a/challenge_5/html_response.rb
+++ b/challenge_5/html_response.rb
@@ -1,0 +1,69 @@
+require 'socket'
+require 'cgi'
+
+server = TCPServer.new 1234
+
+# More info here: https://tools.ietf.org/html/rfc7231#section-6
+STATUS_CODES = {
+  ok: 200
+}
+
+# Accompanying text for status codes
+STATUS_CODES_TEXT = {
+  ok: 'OK'
+}
+
+HTTP_VERSION = 'HTTP/1.1'
+
+def data
+  [
+    {
+      title: 'My awesome blog!',
+      content: 'my favourite HTML tags are <p> and <script>'
+    },
+    {
+      title: 'Another cool blog!',
+      content: 'my favourite HTML tags are <br> and <hr>'
+    }
+  ]
+end
+
+loop do
+  # Accept a client connection
+  client = server.accept
+  puts "Got a new client!"
+  
+  # Read the request line
+  request_line = client.readline.chomp
+  puts "Parsing HTTP request!"
+  method, target, http_version = request_line.split
+
+  puts "Building response for client!"
+  status_line = "#{HTTP_VERSION} #{STATUS_CODES[:ok]} #{STATUS_CODES_TEXT[:ok]}\r\n"
+
+  # Check request target to determine what to render for message body / headers
+  if target == '/show-data'
+    # The browser knows how to add <html> tags and <head> / <body> tags for us!
+    header_field = "Content-Type: text/html\r\n"
+    message_body = ""
+    message_body << "<ul>"
+    data.each do |element|
+      message_body << "<li>"
+      message_body << "<strong>Title: #{CGI.escape_html(element[:title])}</strong>, Content: #{CGI.escape_html(element[:content])}"
+      message_body << "</li>"
+    end
+    message_body << "</ul>"
+  else
+    header_field = "Content-Type: text/plain\r\n"
+    message_body =  "Request method: #{method}, Request target: #{target}, HTTP Version: #{http_version}"
+  end
+
+  # Send response to client
+  client.write(status_line)
+  client.write(header_field)
+  # CRLF to separate the headers from the message body
+  client.write("\r\n")
+  client.write(message_body)
+
+  client.close
+end


### PR DESCRIPTION
In this challenge we:
1) Distinguish between different targets (urls), rendering HTML for the path `/show-data` and a plaintext message otherwise.
2) For the `/show-data` target, we render a list of formatted blog posts (title and content). We store our data in memory as an array of hashes. To build our message, we transform each hash into an HTML-escaped, formatted string. We then wrap it in an `<li>` tag, and then wrap all of the <li> elements in a `<ul>.

The use of `CGI#escapeHTML` is important in case any of our data contains HTML tags.

As with the previous challenge, we write the status line, headers and message body to the client.