### PR TITLE
Challenge 6: POST requests 🎉

### DIFF
--- a/challenge_6/http_post.rb
+++ b/challenge_6/http_post.rb
@@ -1,0 +1,112 @@
+### Require dependencies
+require 'socket'
+require 'cgi'
+require 'uri'
+
+### Define some constants ###
+#############################
+# More info here: https://tools.ietf.org/html/rfc7231#section-6
+STATUS_CODES = {
+  ok: 200,
+  redirect: 303
+}
+
+# Accompanying text for status codes
+STATUS_CODES_TEXT = {
+  ok: 'OK',
+  redirect: 'See Other'
+}
+
+HTTP_VERSION = 'HTTP/1.1'
+
+BLOG_DATA = 
+[
+  {
+    title: 'My awesome blog!',
+    content: 'my favourite HTML tags are <p> and <script>'
+  },
+  {
+    title: 'Another cool blog!',
+    content: 'my favourite HTML tags are <br> and <hr>'
+  }
+]
+
+CRLF = "\r\n"
+#############################
+
+server = TCPServer.new 1234
+
+loop do
+  # Accept a client connection
+  client = server.accept
+  puts "Got a new client!"
+  
+  # Read the request line
+  request_line = client.readline.chomp
+  puts "Parsing HTTP request!"
+  method, target, http_version = request_line.split
+
+  puts "Building response for client!"
+  status_line = "#{HTTP_VERSION} #{STATUS_CODES[:ok]} #{STATUS_CODES_TEXT[:ok]}"
+  header_field = "Content-Type: text/html"
+
+  # Check request target to determine what to send back to client
+  if target == '/show-data'
+    message_body = ""
+    message_body << "<ul>"
+    BLOG_DATA.each do |element|
+      message_body << "<li>"
+      message_body << "<strong>Title: #{CGI.escape_html(element[:title])}</strong>, Content: #{CGI.escape_html(element[:content])}"
+      message_body << "</li>"
+    end
+    message_body << "</ul>"
+  elsif target == '/create-post' && method == 'POST'
+    status_line = "#{HTTP_VERSION} #{STATUS_CODES[:redirect]} #{STATUS_CODES_TEXT[:redirect]}"
+    # Don't need a Content-Type here, we're redirecting!
+    header_field = "Location: /show-data"
+
+    puts "Got a new POST request!"
+    # Not sure if this is how to do this
+    # Let's try reading all the headers in until we get a line that is just CRLF
+    headers = {}
+    line = client.readline
+    while (line = client.readline) != CRLF
+      header_name, header_value = line.chomp.split(": ")
+      headers[header_name] = header_value
+    end
+    content_length = headers["Content-Length"]
+    body = client.read(content_length.to_i)
+    post = Hash[URI.decode_www_form(body)]
+    post.transform_keys! { |key| key.to_sym }
+    BLOG_DATA << post
+  else
+    # Main Page
+    message_body =  ""
+    message_body << "<p><strong>Submit a new Blog Post!</p></strong>"
+    # Method = POST
+    # Encoding type = application/x-www-form-urlencoded (usual encoding system, Ruby has built-in decoder)
+    # Action = /create-post (Seems like this just needs to be a relative target path, but docs use full URL)
+    message_body << "<form method=\"post\" enctype=\"application/x-www-form-urlencoded\" action=\"/create-post\">"
+    message_body << "<p><label>Blog Title: <input name='title'></label></p>"
+    message_body << "<p><label>Content: <textarea name='content'></textarea></label></p>"
+    message_body << "<p><button>Submit post</button></p>"
+    message_body << "</form>"
+  end
+
+  # Send response to client
+  client.write(status_line + CRLF)
+  client.write(header_field + CRLF)
+  # CRLF to separate the headers from the message body
+  client.write(CRLF)
+  client.write(message_body)
+
+  client.close
+end
+
+# - add a form to the main page with multiple input fields (and the correct method, action and enctype) which will send a POST request to a new request path when it’s submitted;
+# - accept a POST request to that new request path;
+# - read the headers from the POST request to determine the Content-Length;
+# - read the request body from the POST request;
+# - decode the application/x-www-form-urlencoded-encoded request body to extract the values of the form fields;
+# - make a new data item using those values and add it to the application’s collection of data items; and
+# - send a response which directs the user back to the main page somehow.

--- a/challenge_6/http_post.rb
+++ b/challenge_6/http_post.rb
@@ -8,13 +8,13 @@ require 'uri'
 # More info here: https://tools.ietf.org/html/rfc7231#section-6
 STATUS_CODES = {
   ok: 200,
-  redirect: 303
+  see_other: 303
 }
 
 # Accompanying text for status codes
 STATUS_CODES_TEXT = {
   ok: 'OK',
-  redirect: 'See Other'
+  see_other: 'See Other'
 }
 
 HTTP_VERSION = 'HTTP/1.1'
@@ -47,11 +47,9 @@ loop do
   method, target, http_version = request_line.split
 
   puts "Building response for client!"
-  status_line = "#{HTTP_VERSION} #{STATUS_CODES[:ok]} #{STATUS_CODES_TEXT[:ok]}"
-  header_field = "Content-Type: text/html"
-
-  # Check request target to determine what to send back to client
-  if target == '/show-data'
+  # Check method type and request target to determine what to send back to client
+  case [method, target]
+  when ['GET', '/show-data']
     message_body = ""
     message_body << "<ul>"
     BLOG_DATA.each do |element|
@@ -60,25 +58,27 @@ loop do
       message_body << "</li>"
     end
     message_body << "</ul>"
-  elsif target == '/create-post' && method == 'POST'
-    status_line = "#{HTTP_VERSION} #{STATUS_CODES[:redirect]} #{STATUS_CODES_TEXT[:redirect]}"
-    # Don't need a Content-Type here, we're redirecting!
-    header_field = "Location: /show-data"
 
+    # Prepare response
+    status_code = :ok
+    header_field = "Content-Type: text/html"
+  when ['POST', '/create-post']
     puts "Got a new POST request!"
-    # Not sure if this is how to do this
-    # Let's try reading all the headers in until we get a line that is just CRLF
     headers = {}
     line = client.readline
     while (line = client.readline) != CRLF
-      header_name, header_value = line.chomp.split(": ")
+      header_name, _, header_value = line.chomp.partition(': ')
       headers[header_name] = header_value
     end
     content_length = headers["Content-Length"]
     body = client.read(content_length.to_i)
     post = Hash[URI.decode_www_form(body)]
-    post.transform_keys! { |key| key.to_sym }
+    post.transform_keys!(&:to_sym)
     BLOG_DATA << post
+
+    # Prepare response
+    status_code = :see_other
+    header_field = "Location: /show-data" # NOTE: Don't need a Content-Type here, we're redirecting!
   else
     # Main Page
     message_body =  ""
@@ -86,12 +86,19 @@ loop do
     # Method = POST
     # Encoding type = application/x-www-form-urlencoded (usual encoding system, Ruby has built-in decoder)
     # Action = /create-post (Seems like this just needs to be a relative target path, but docs use full URL)
-    message_body << "<form method=\"post\" enctype=\"application/x-www-form-urlencoded\" action=\"/create-post\">"
+    message_body << "<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>"
     message_body << "<p><label>Blog Title: <input name='title'></label></p>"
     message_body << "<p><label>Content: <textarea name='content'></textarea></label></p>"
     message_body << "<p><button>Submit post</button></p>"
     message_body << "</form>"
+
+    # Prepare response
+    status_code = :ok
+    header_field = "Content-Type: text/html"
   end
+
+  # Build our status line using whichever status_code we've set
+  status_line = "#{HTTP_VERSION} #{STATUS_CODES[status_code]} #{STATUS_CODES_TEXT[status_code]}"
 
   # Send response to client
   client.write(status_line + CRLF)
@@ -102,11 +109,3 @@ loop do
 
   client.close
 end
-
-# - add a form to the main page with multiple input fields (and the correct method, action and enctype) which will send a POST request to a new request path when it’s submitted;
-# - accept a POST request to that new request path;
-# - read the headers from the POST request to determine the Content-Length;
-# - read the request body from the POST request;
-# - decode the application/x-www-form-urlencoded-encoded request body to extract the values of the form fields;
-# - make a new data item using those values and add it to the application’s collection of data items; and
-# - send a response which directs the user back to the main page somehow.


### PR DESCRIPTION
In this challenge, we introduced forms, post requests, and redirects!
- The main page of the web application renders an HTML form
      - From [the docs](https://html.spec.whatwg.org/#implementing-the-server-side-processing-for-a-form): "For each form control you want submitted, you then have to give a name that will be used to refer to the data in the submission."
- We specify the method (POST), action (what endpoint / URL should the data be submitted to), and enctype (how we encode the data)
- We added a new target, `/create-post`, that will create a new blog post (it accepts `POST` requests only)
- Inside the `/create-post` branch, we handle parsing the request, extracting headers, and then creating a hash for the new post and pushing it into our `BLOG_DATA` structure
- If a client submits a POST request to `/create-post`, we redirect them to the `/show-data` URL where they can view theiir new post! (This means adding a `Location` header indicating the URL to redirect to, as well as using a status code of [303 - See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303))

Other Takeaways:
* Why is it important to know `Content-Length`?
     * The browser sends data over the network
     * All data might come in at once, but we should imagine it "trickling" over the network, since it might _not_ always come all at once (ie. uploading an image might take a while!)
     * When we want to read data off the socket, we can either: 1) Ask it for as much data as it has, or 2) Ask it to give us X amount of data
     * We need to tell the OS to wait to receive all data in the case where it doesn't come right away in the initial TCP connection
     * We also don't want to pick an arbitrary amount (ie. we should know _exactly_ how much data we'll need to read in the message body) because the OS will wait until it has read the exact right amount, or until the client has closed the connection.. Which can be an indeterminate amount of time 😄  