### PR TITLE
Challenge 10 - Introducing `Rack::Response`

### DIFF
--- a/challenge_10/rack_response.rb
+++ b/challenge_10/rack_response.rb
@@ -1,0 +1,93 @@
+### Require dependencies
+require 'cgi'
+require 'rack/handler/puma'
+require 'rack'
+require 'uri'
+require 'yaml/store'
+
+### Status codes
+STATUS_CODES = {
+  ok: 200,
+  see_other: 303
+}
+
+# Struct to define what a Blog looks like
+Blog = Struct.new(:title, :content, keyword_init: true)
+
+def set_up_blogs_store(store_path)
+  store = YAML::Store.new(File.expand_path(store_path, __dir__))
+  store.transaction do
+    store[:blogs] = [] if store[:blogs].nil?
+  end
+  
+  # Seed some blog data
+  # Comment out if you'd like to start from scratch!
+  store.transaction do
+    if store[:blogs].empty?
+      store[:blogs] << Blog.new(title: 'My awesome blog!', content: 'my favourite HTML tags are <p> and <script>')
+      store[:blogs] << Blog.new(title: 'Another cool blog!', content: 'my favourite HTML tags are <br> and <hr>')
+    end
+  end
+  store
+end
+
+# Set up YAML store
+store = set_up_blogs_store('blogs.yml')
+
+app = lambda { |environment|
+  puts 'Rack app got a request!'
+  # Build Rack request
+  request = Rack::Request.new(environment)
+
+  headers = {}
+  body = []
+
+  if request.get? && request.path == '/show-data'
+    body << '<ul>'
+    blog_data = store.transaction { store[:blogs] }
+    blog_data.each do |element|
+      body << '<li>'
+      body << "<strong>Title: #{CGI.escape_html(element.title)}</strong>, Content: #{CGI.escape_html(element.content)}"
+      body << '</li>'
+    end
+    body << '</ul>'
+
+    # Prepare response
+    status = :ok
+    headers['Content-Type'] = 'text/html'
+  elsif request.get? && request.path == '/'
+    body << '<p><strong>Submit a new Blog Post!</p></strong>'
+    body << "<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>"
+    body << "<p><label>Blog Title: <input name='title'></label></p>"
+    body << "<p><label>Content: <textarea name='content'></textarea></label></p>"
+    body << '<p><button>Submit post</button></p>'
+    body << '</form>'
+
+    # Prepare response
+    status = :ok
+    headers['Content-Type'] = 'text/html'
+  elsif request.get?
+    body << "method is #{request.request_method}, path is #{request.path}"
+    status = :ok
+    headers['Content-Type'] = 'text/plain'
+  elsif request.post? && request.path == '/create-post'
+    puts 'Got a new POST request!'
+
+    post = Blog.new
+    request.params.each do |name, value|
+      post[name] = value
+    end
+
+    store.transaction do
+      store[:blogs] << post
+    end
+
+    # Prepare response
+    status = :see_other
+    headers['Location'] = '/show-data' # NOTE: Don't need a Content-Type here, we're redirecting!
+  end
+
+  [STATUS_CODES[status], headers, body]
+}
+
+Rack::Handler::Puma.run(app, Port: 1234, Verbose: true)

--- a/challenge_10/rack_response.rb
+++ b/challenge_10/rack_response.rb
@@ -2,7 +2,6 @@
 require 'cgi'
 require 'rack/handler/puma'
 require 'rack'
-require 'uri'
 require 'yaml/store'
 
 # Struct to define what a Blog looks like
@@ -49,7 +48,7 @@ app = lambda { |environment|
         end
         sleep(1)
       end
-     response.write '</ul>'
+      response.write '</ul>'
     end
   elsif request.get? && request.path == '/'
     response.write '<p><strong>Submit a new Blog Post!</p></strong>'


### PR DESCRIPTION
In this challenge, we introduce a `Rack::Response` object to handle returning the Rack response, rather than building the array to be returned ourselves.

We also experiment with using the block version of `Response#finish`, which [takes a block](https://github.com/rack/rack/blob/master/lib/rack/response.rb#L80), and [returns self as the body](https://github.com/rack/rack/blob/master/lib/rack/response.rb#L89) of the Rack response. `Rack::Response` implements [#each](https://github.com/rack/rack/blob/master/lib/rack/response.rb#L98-L106), which takes a callback block and sets the response writer to be that callback. The app server can then pass a block to `each`, and this block gets called when we [`#write` to the response body](https://github.com/rack/rack/blob/master/lib/rack/response.rb#L115). This allows us to "stream" response content to the client (kind of like long polling) iteratively, rather than filling up a buffer and then having to terminate the response by calling `#finish`.

Example:

Let's say the app server has a `#send_response` method like this (this example is taken from https://github.com/macournoyer/tube/blob/master/tube.rb):
```ruby
    def send_response(env)
      status, headers, body = @app.call(env)
      reason = REASONS[status]

      @socket.write "HTTP/1.1 #{status} #{reason}\r\n"
      headers.each_pair do |name, value|
        @socket.write "#{name}: #{value}\r\n"
      end
      @socket.write "\r\n"
      body.each do |chunk|
        @socket.write chunk
      end
      body.close if body.respond_to? :close

      close
    end
```

And our Rack-compliant web app does this (example straight in this PR!):
```ruby
response.finish do
      response.write '<ul>'
      blog_data = store.transaction { store[:blogs] }
      loop do
        blog_data.each do |element|
          response.write '<li>'
          response.write "<strong>Title: #{CGI.escape_html(element.title)}</strong>, Content: #{CGI.escape_html(element.content)}"
          response.write '</li>'
        end
        sleep(1)
      end
     response.write '</ul>'
end
```

Then, in the `Rack::Response` object:
* `@block` is the block we send to `#finish` that writes to the response object in an infinite loop
* The `body` in the app server is actually our response instance
* Calling `body.each` in the app server sets the `@writer` to the block passed to `#each` (which is the block with `@socket.write chunk`)
* We then [call the `block`](https://github.com/rack/rack/blob/master/lib/rack/response.rb#L104), which performs `#write`s to the response object
* Now that the writer has actually been set to the app server's callback block, calling `response.write` actually invokes the `@socket.write chunk` proc
* This has us write straight to the socket! 😍 