### PR TITLE
Challenge 13 - Use `Action Dispatch` to route requests

### DIFF
--- a/challenge_13/action_dispatch.rb
+++ b/challenge_13/action_dispatch.rb
@@ -2,7 +2,6 @@
 require 'action_dispatch'
 require 'active_record'
 require 'cgi'
-require 'rack/handler/puma'
 require 'rack'
 
 class Blog < ActiveRecord::Base; end
@@ -74,7 +73,8 @@ class MyApp
       }
       match '*path', via: :all, to: -> environment {
         response = Rack::Response.new
-        response.write "Sorry, I don’t know what #{environment['PATH_INFO']} is"
+        request = Rack::Request.new(environment)
+        response.write "Sorry, I don’t know what #{request.path_info} is"
         response.content_type = 'text/plain'
         response.status = 404
         response.finish

--- a/challenge_13/action_dispatch.rb
+++ b/challenge_13/action_dispatch.rb
@@ -1,0 +1,74 @@
+### Require dependencies
+require 'active_record'
+require 'cgi'
+require 'rack/handler/puma'
+require 'rack'
+
+class Blog < ActiveRecord::Base; end
+
+ActiveRecord::Base.establish_connection(
+  adapter:  "sqlite3",
+  database: "application.sqlite3"
+)
+
+# Create the table if it doesn't exist, seed some data
+ActiveRecord::Schema.define do
+  unless table_exists?(:blogs)
+    create_table :blogs do |t|
+      t.string :title
+      t.text :content
+    end
+    Blog.create!(title: 'My awesome blog!', content: 'my favourite HTML tags are <p> and <script>')
+    Blog.create!(title: 'Another cool blog!', content: 'my favourite HTML tags are <br> and <hr>')
+  end
+end
+
+app = lambda { |environment|
+  puts 'Rack app got a request!'
+  # Build Rack request
+  request = Rack::Request.new(environment)
+
+  # Build Rack response
+  response = Rack::Response.new
+
+  if request.get? && request.path == '/show-data'
+    response.content_type = 'text/html'
+    response.finish do
+      response.write '<ul>'
+
+      Blog.all.each do |blog|
+        response.write '<li>'
+        response.write "<strong>Title: #{CGI.escape_html(blog.title)}</strong>, Content: #{CGI.escape_html(blog.content)}"
+        response.write '</li>'
+      end
+      response.write '</ul>'
+    end
+  elsif request.get? && request.path == '/'
+    response.write '<p><strong>Submit a new Blog Post!</p></strong>'
+    response.write "<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>"
+    response.write "<p><label>Blog Title: <input name='title'></label></p>"
+    response.write "<p><label>Content: <textarea name='content'></textarea></label></p>"
+    response.write '<p><button>Submit post</button></p>'
+    response.write '</form>'
+
+    # Prepare response
+    response.content_type = 'text/html'
+    response.finish
+  elsif request.get?
+    response.write "method is #{request.request_method}, path is #{request.path}"
+    response.content_type = 'text/plain'
+    response.finish
+  elsif request.post? && request.path == '/create-post'
+    puts 'Got a new POST request!'
+
+    # The request params can be passed directly to the Blog's create method - neat!
+    blog = Blog.create!(request.params)
+
+    # Prepare response
+    response.redirect('/show-data', 303)
+    response.finish
+  end
+}
+
+# Run the Puma app server with our web application
+Rack::Handler::Puma.run(app, Port: 1234, Verbose: true)

--- a/challenge_13/config.ru
+++ b/challenge_13/config.ru
@@ -20,7 +20,7 @@ class CharsetMiddleware
 
   def call(environment)
     response = Rack::Response[*@app.call(environment)]
-    response.content_type = "#{response.content_type}; charset=#{@charset}"
+    response.content_type = "#{response.content_type}; charset=#{@charset}" unless response.media_type_params.any?
     response.finish
   end
 end

--- a/challenge_13/config.ru
+++ b/challenge_13/config.ru
@@ -1,0 +1,31 @@
+require_relative 'action_dispatch'
+
+class LoggerMiddleware
+  def initialize(app, string)
+    @app = app
+    @string = string
+  end
+
+  def call(environment)
+    puts @string
+    @app.call(environment)
+  end
+end
+
+class CharsetMiddleware
+  def initialize(app, charset: 'UTF-8')
+    @app = app
+    @charset = charset
+  end
+
+  def call(environment)
+    response = Rack::Response[*@app.call(environment)]
+    response.content_type = "#{response.content_type}; charset=#{@charset}"
+    response.finish
+  end
+end
+
+use LoggerMiddleware, 'Rack app got a request!'
+use CharsetMiddleware
+
+run MyApp.new


### PR DESCRIPTION
 In this challenge, we introduce the Action Dispatch framework to handle parsing our incoming HTTP requests and routing them to the correct endpoint.

But what is an endpoint?!
- Conforms to the same specification as a Rack application, in that it expects to be called with an `environment` hash and then return a three-element array
- We initialize an [`ActionDispatch::Routing::RouteSet`](https://www.rubydoc.info/docs/rails/ActionDispatch/Routing/RouteSet), which can draw routes using a `#draw` method that takes a block declaring the routes to draw
- The[ DSL for mapping routes ](https://www.rubydoc.info/docs/rails/ActionDispatch/Routing/Mapper/HttpHelpers) uses `<action> <path>, to: <endpoint>`, where `action` is `get`, `put`, `post`, etc...

The `RouteSet` is super duper smart and can even route based on wildcard patterns:
```ruby
      match '*path', via: :all, to: -> environment {
        response = Rack::Response.new
        response.write "Sorry, I don’t know what #{environment['PATH_INFO']} is"
        response.content_type = 'text/plain'
        response.status = 404
        response.finish
      }
```

**BIG TAKEAWAY!**
> The end result is to stitch several small Rack applications (“endpoints”) together into a single large Rack application which can serve responses by directing requests to the correct endpoint.

The router essentially stitches together these mini Rack apps (endpoints), and then provides a `.call` method that takes the `environment`, and defers the work to the appropriate endpoint.

We can wrap the call to the router inside _another_ Rack application like so: 
```ruby
app = lambda { |environment| router.call(environment) }
```
This allows us to decorate the app with additional behaviour by wrapping it in middleware-esque classes! See https://github.com/adrianna-chang-shopify/learning-project/commit/f2dbf9921a1f214b50d4bc0dc0d145ee475bc79e for all the fun Tom and I had implementing these 🎉 

**config.ru fun 🦘**
https://github.com/adrianna-chang-shopify/learning-project/commit/34e2322dbec017fac6d9ef8245aa931f21c21c11 refactors our main app file to actually have an invokable endpoint that we can call from config.ru. @tomstuart let me know if this is an okay way to do this! To sum, we:
- Make our rack application an actual Ruby object in the `action_dispatch.rb` file - on initialize, it creates a routeset and draws the routes we want
- It implements `call`, which takes an environment argument and returns the results of calling our router (conforms to the Rack specification)
- In `config.ru`, we require our app file, implement our middleware logic, and then use `run MyApp.new`

Now, we can just use `puma` from the console and it all works! 🎉  (I couldn't figure out how to specify the port number / verbose mode when using a config.ru 🤔 )