### PR TITLE
Challenge 14 - Introducing Action Controller!

### DIFF
--- a/challenge_13/config.ru
+++ b/challenge_13/config.ru
@@ -20,7 +20,7 @@ class CharsetMiddleware
 
   def call(environment)
     response = Rack::Response[*@app.call(environment)]
-    response.content_type = "#{response.content_type}; charset=#{@charset}" unless response.media_type_params.any?
+    response.content_type = "#{response.content_type}; charset=#{@charset}" unless response.media_type_params["charset"].present?
     response.finish
   end
 end

--- a/challenge_14/action_controller.rb
+++ b/challenge_14/action_controller.rb
@@ -1,0 +1,84 @@
+### Require dependencies
+require 'action_dispatch'
+require 'active_record'
+require 'cgi'
+require 'rack'
+
+class Blog < ActiveRecord::Base; end
+
+ActiveRecord::Base.establish_connection(
+  adapter:  "sqlite3",
+  database: "application.sqlite3"
+)
+
+# Create the table if it doesn't exist, seed some data
+ActiveRecord::Schema.define do
+  unless table_exists?(:blogs)
+    create_table :blogs do |t|
+      t.string :title
+      t.text :content
+    end
+    Blog.create!(title: 'My awesome blog!', content: 'my favourite HTML tags are <p> and <script>')
+    Blog.create!(title: 'Another cool blog!', content: 'my favourite HTML tags are <br> and <hr>')
+  end
+end
+
+class MyApp
+  def initialize
+    @router = ActionDispatch::Routing::RouteSet.new
+    draw_routes
+  end
+
+  def call(environment)
+    @router.call(environment)
+  end
+
+  private
+
+  def draw_routes
+    @router.draw do
+      get '/', to: -> environment {
+        response = Rack::Response.new
+        response.write '<p><strong>Submit a new Blog Post!</p></strong>'
+        response.write "<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>"
+        response.write "<p><label>Blog Title: <input name='title'></label></p>"
+        response.write "<p><label>Content: <textarea name='content'></textarea></label></p>"
+        response.write '<p><button>Submit post</button></p>'
+        response.write '</form>'
+        response.content_type = 'text/html'
+        response.finish
+      }
+      get '/show-data', to: -> environment {
+        response = Rack::Response.new
+        response.content_type = 'text/html'
+        response.finish do
+          response.write '<ul>'
+    
+          Blog.all.each do |blog|
+            response.write '<li>'
+            response.write "<strong>Title: #{CGI.escape_html(blog.title)}</strong>, Content: #{CGI.escape_html(blog.content)}"
+            response.write '</li>'
+          end
+          response.write '</ul>'
+        end
+      }
+      post 'create-post', to: -> environment {
+        response = Rack::Response.new
+        request = Rack::Request.new(environment)
+        puts 'Got a new POST request!'
+    
+        Blog.create!(request.params)
+        response.redirect('/show-data', 303)
+        response.finish
+      }
+      match '*path', via: :all, to: -> environment {
+        response = Rack::Response.new
+        request = Rack::Request.new(environment)
+        response.write "Sorry, I don’t know what #{request.path_info} is"
+        response.content_type = 'text/plain'
+        response.status = 404
+        response.finish
+      }
+    end
+  end
+end

--- a/challenge_14/action_controller.rb
+++ b/challenge_14/action_controller.rb
@@ -3,7 +3,6 @@ require 'action_controller'
 require 'action_dispatch'
 require 'active_record'
 require 'cgi'
-require 'rack'
 
 class Blog < ActiveRecord::Base; end
 
@@ -26,39 +25,41 @@ end
 
 class AppController < ActionController::Base
   def root
-    response = ""
-    response += "<p><strong>Submit a new Blog Post!</p></strong>"
-    response += "<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>"
-    response += "<p><label>Blog Title: <input name='title'></label></p>"
-    response += "<p><label>Content: <textarea name='content'></textarea></label></p>"
-    response += "<p><button>Submit post</button></p>"
-    response += "</form>"
-    render html: response.html_safe
+    response_body = ""
+    response_body += "<p><strong>Submit a new Blog Post!</p></strong>"
+    response_body += "<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>"
+    response_body += "<p><label>Blog Title: <input name='title'></label></p>"
+    response_body += "<p><label>Content: <textarea name='content'></textarea></label></p>"
+    response_body += "<p><button>Submit post</button></p>"
+    response_body += "</form>"
+    render html: response_body.html_safe
   end
 
   def show_data
-    response = ""
-    response += "<ul>"
+    response_body = ""
+    response_body += "<ul>"
 
     Blog.all.each do |blog|
-      response += "<li>"
-      response += "<strong>Title: #{CGI.escape_html(blog.title)}</strong>, Content: #{CGI.escape_html(blog.content)}"
-      response += "</li>"
+      response_body += "<li>"
+      response_body += "<strong>Title: #{CGI.escape_html(blog.title)}</strong>, Content: #{CGI.escape_html(blog.content)}"
+      response_body += "</li>"
     end
-    response += "</ul>"
-    render html: response.html_safe
+    response_body += "</ul>"
+    render html: response_body.html_safe
   end
 
   def create_post
     puts 'Got a new POST request!'
 
+    # Alternatively, we can explicitly grab the params we want to pass to the #create method
+    # Blog.create!(title: params[:title], content: params[:content])
     Blog.create!(params.permit(:title, :content))
     redirect_to "/show-data", status: :see_other
   end
 
   def not_found
-    response = "Sorry, I don’t know what #{request.path_info} is"
-    render plain: response, status: :not_found
+    response_body = "Sorry, I don’t know what #{request.path_info} is"
+    render plain: response_body, status: :not_found
   end
 end
 
@@ -76,7 +77,7 @@ class MyApp
 
   def draw_routes
     @router.draw do
-      get '/', to: AppController.action(:root)
+      root to: AppController.action(:root)
       get '/show-data', to: AppController.action(:show_data)
       post 'create-post', to: AppController.action(:create_post)
       match '*path', via: :all, to: AppController.action(:not_found)

--- a/challenge_14/config.ru
+++ b/challenge_14/config.ru
@@ -1,0 +1,31 @@
+require_relative 'action_dispatch'
+
+class LoggerMiddleware
+  def initialize(app, string)
+    @app = app
+    @string = string
+  end
+
+  def call(environment)
+    puts @string
+    @app.call(environment)
+  end
+end
+
+class CharsetMiddleware
+  def initialize(app, charset: 'UTF-8')
+    @app = app
+    @charset = charset
+  end
+
+  def call(environment)
+    response = Rack::Response[*@app.call(environment)]
+    response.content_type = "#{response.content_type}; charset=#{@charset}" unless response.media_type_params["charset"].present?
+    response.finish
+  end
+end
+
+use LoggerMiddleware, 'Rack app got a request!'
+use CharsetMiddleware
+
+run MyApp.new

--- a/challenge_14/config.ru
+++ b/challenge_14/config.ru
@@ -1,4 +1,4 @@
-require_relative 'action_dispatch'
+require_relative 'action_controller'
 
 class LoggerMiddleware
   def initialize(app, string)

--- a/challenge_14/config.ru
+++ b/challenge_14/config.ru
@@ -12,20 +12,6 @@ class LoggerMiddleware
   end
 end
 
-class CharsetMiddleware
-  def initialize(app, charset: 'UTF-8')
-    @app = app
-    @charset = charset
-  end
-
-  def call(environment)
-    response = Rack::Response[*@app.call(environment)]
-    response.content_type = "#{response.content_type}; charset=#{@charset}" unless response.media_type_params["charset"].present?
-    response.finish
-  end
-end
-
 use LoggerMiddleware, 'Rack app got a request!'
-use CharsetMiddleware
 
 run MyApp.new


### PR DESCRIPTION
In this challenge, we introduce the Action Controller library. It offers us a way to organize our Rack endpoints in a class (as methods - but note that these are kind of "overloaded" method definitions), and gives us some nice helper methods (`#params`, `#render`, etc...) so that we no longer have to do the work of creating Rack request and response objects ourselves.

Note that, unlike typical OO programming, these controller methods are _not_ intended to be used on an instance of a controller class, but are always intended to be used by calling `MyController.action(:<method_name>)`. It is this `.action` method that actually transforms the contents of the method into a Rack endpoint (ie. a Proc capable of receiving an environment hash, and returning the three-element array that Rack endpoints must return).

### Perks of using Action Controller endpoints
- Don't have to create Rack request / response objects anymore!
- Can combine the content type and status into a single line with a more human-readable DSL, ie: `render plain: response, status: :not_found`
- Similar to the above, we now have helpers for things like status codes (`status: :see_other`, etc...), so we can use those without needing to remember the numbers corresponding to different status codes!

### Key Takeaways from Tom
- The choice to have controller endpoints constructed as overloaded method definitions was simply a design design made by humans! This could easily have been some other DSL (ie. how [Sinatra defines endpoints](http://sinatrarb.com/))
- Always need to call `html_safe` on the response string if we are storing raw HTML in it, because Action Controller's default is to escape any HTML contained in the response body
- The Action Controller endpoints return the body as an `ActionDispatch::Response`, and these include `Rack::Request::Helpers`, which allows us to still use `request.path_info`:
```ruby
  def not_found
    response = "Sorry, I don’t know what #{request.path_info} is"
    render plain: response, status: :not_found
  end
```
- We got to experiment with the [Strong Parameters API](https://api.rubyonrails.org/classes/ActionController/StrongParameters.html) here:
```ruby
  def create_post
    puts 'Got a new POST request!'

    Blog.create!(params.permit(:title, :content))
    redirect_to "/show-data", status: :see_other
  end
```
If we just passed the parameters directly into `Blog.create!`, we would raise an `ActiveModel::ForbiddenAttributesError ` exception because it'd be using mass assignment without explicitly permitting those params.