### PR TITLE
Challenge 15 - Inline Action View Templates

### DIFF
--- a/challenge_15/action_view.rb
+++ b/challenge_15/action_view.rb
@@ -1,0 +1,86 @@
+### Require dependencies
+require 'action_controller'
+require 'action_dispatch'
+require 'active_record'
+require 'cgi'
+
+class Blog < ActiveRecord::Base; end
+
+ActiveRecord::Base.establish_connection(
+  adapter:  "sqlite3",
+  database: "application.sqlite3"
+)
+
+# Create the table if it doesn't exist, seed some data
+ActiveRecord::Schema.define do
+  unless table_exists?(:blogs)
+    create_table :blogs do |t|
+      t.string :title
+      t.text :content
+    end
+    Blog.create!(title: 'My awesome blog!', content: 'my favourite HTML tags are <p> and <script>')
+    Blog.create!(title: 'Another cool blog!', content: 'my favourite HTML tags are <br> and <hr>')
+  end
+end
+
+class AppController < ActionController::Base
+  def root
+    response_body = ""
+    response_body += "<p><strong>Submit a new Blog Post!</p></strong>"
+    response_body += "<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>"
+    response_body += "<p><label>Blog Title: <input name='title'></label></p>"
+    response_body += "<p><label>Content: <textarea name='content'></textarea></label></p>"
+    response_body += "<p><button>Submit post</button></p>"
+    response_body += "</form>"
+    render html: response_body.html_safe
+  end
+
+  def show_data
+    response_body = ""
+    response_body += "<ul>"
+
+    Blog.all.each do |blog|
+      response_body += "<li>"
+      response_body += "<strong>Title: #{CGI.escape_html(blog.title)}</strong>, Content: #{CGI.escape_html(blog.content)}"
+      response_body += "</li>"
+    end
+    response_body += "</ul>"
+    render html: response_body.html_safe
+  end
+
+  def create_post
+    puts 'Got a new POST request!'
+
+    # Alternatively, we can explicitly grab the params we want to pass to the #create method
+    # Blog.create!(title: params[:title], content: params[:content])
+    Blog.create!(params.permit(:title, :content))
+    redirect_to "/show-data", status: :see_other
+  end
+
+  def not_found
+    response_body = "Sorry, I don’t know what #{request.path_info} is"
+    render plain: response_body, status: :not_found
+  end
+end
+
+class MyApp
+  def initialize
+    @router = ActionDispatch::Routing::RouteSet.new
+    draw_routes
+  end
+
+  def call(environment)
+    @router.call(environment)
+  end
+
+  private
+
+  def draw_routes
+    @router.draw do
+      root to: AppController.action(:root)
+      get '/show-data', to: AppController.action(:show_data)
+      post 'create-post', to: AppController.action(:create_post)
+      match '*path', via: :all, to: AppController.action(:not_found)
+    end
+  end
+end

--- a/challenge_15/action_view.rb
+++ b/challenge_15/action_view.rb
@@ -2,7 +2,6 @@
 require 'action_controller'
 require 'action_dispatch'
 require 'active_record'
-require 'cgi'
 
 class Blog < ActiveRecord::Base; end
 
@@ -39,11 +38,13 @@ class AppController < ActionController::Base
   def show_data
     @blogs = Blog.all
 
+    # Note! ERB interpolated HTML is escaped unless marked as HTML safe / raw helper used
+
     erb_response = <<~ERB
       <ul>
       <% @blogs.each do |blog| %>
         <li>
-          <strong>Title: <%= CGI.escape_html(blog.title) %> </strong>, Content: <%= CGI.escape_html(blog.content) %>
+          <strong>Title: <%= blog.title %> </strong>, Content: <%= blog.content %>
         </li>
       <% end %>
       </ul>

--- a/challenge_15/action_view.rb
+++ b/challenge_15/action_view.rb
@@ -25,41 +25,47 @@ end
 
 class AppController < ActionController::Base
   def root
-    response_body = ""
-    response_body += "<p><strong>Submit a new Blog Post!</p></strong>"
-    response_body += "<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>"
-    response_body += "<p><label>Blog Title: <input name='title'></label></p>"
-    response_body += "<p><label>Content: <textarea name='content'></textarea></label></p>"
-    response_body += "<p><button>Submit post</button></p>"
-    response_body += "</form>"
-    render html: response_body.html_safe
+    erb_response = <<~ERB
+      <p><strong>Submit a new Blog Post!</p></strong>
+      <form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>
+      <label>Blog Title: <input name='title'></label></p>
+      <p><label>Content: <textarea name='content'></textarea></label></p>
+      <p><button>Submit post</button></p>
+      </form>
+    ERB
+    render inline: erb_response
   end
 
   def show_data
-    response_body = ""
-    response_body += "<ul>"
+    @blogs = Blog.all
 
-    Blog.all.each do |blog|
-      response_body += "<li>"
-      response_body += "<strong>Title: #{CGI.escape_html(blog.title)}</strong>, Content: #{CGI.escape_html(blog.content)}"
-      response_body += "</li>"
-    end
-    response_body += "</ul>"
-    render html: response_body.html_safe
+    erb_response = <<~ERB
+      <ul>
+      <% @blogs.each do |blog| %>
+        <li>
+          <strong>Title: <%= CGI.escape_html(blog.title) %> </strong>, Content: <%= CGI.escape_html(blog.content) %>
+        </li>
+      <% end %>
+      </ul>
+    ERB
+    render inline: erb_response
   end
 
   def create_post
     puts 'Got a new POST request!'
 
-    # Alternatively, we can explicitly grab the params we want to pass to the #create method
     # Blog.create!(title: params[:title], content: params[:content])
     Blog.create!(params.permit(:title, :content))
     redirect_to "/show-data", status: :see_other
   end
 
   def not_found
-    response_body = "Sorry, I don’t know what #{request.path_info} is"
-    render plain: response_body, status: :not_found
+    @request_path = request.path_info
+
+    erb_response = <<~ERB
+      Sorry, I don’t know what <%= @request_path %> is 😢
+    ERB
+    render inline: erb_response, status: :not_found
   end
 end
 

--- a/challenge_15/config.ru
+++ b/challenge_15/config.ru
@@ -1,0 +1,17 @@
+require_relative 'action_view'
+
+class LoggerMiddleware
+  def initialize(app, string)
+    @app = app
+    @string = string
+  end
+
+  def call(environment)
+    puts @string
+    @app.call(environment)
+  end
+end
+
+use LoggerMiddleware, 'Rack app got a request!'
+
+run MyApp.new


### PR DESCRIPTION
In this challenge, we render inline (`render :inline`) ERB templates in our `AppController` actions, rather than rendering strings with raw HTML (`render :html`).

ERB is a templating system that allows ruby code to be embedded in our HTML documents. ERB supplied to Action Controller's `render` method using the `:inline` option is automatically HTML-escaped (we no longer need to use `CGI.escape_html` to HTML escape our blog title / content).

The ERB template also has access to any instance variables defined in the controller action, allowing us to do this:
```ruby
    @blogs = Blog.all
    erb_response = <<~ERB
      <ul>
      <% @blogs.each do |blog| %>
        <li>
          <strong>Title: <%= blog.title %> </strong>, Content: <%= blog.content %>
        </li>
      <% end %>
      </ul>
    ERB
```

🔍  On Action View being separate from Action Pack
* Maybe so that Action View can be used in isolation from Action Controller / Action Dispatch
* Interestingly, Action Controller is still dependent on Action View, and [requires it as a dependency in `ActionController::Base`](https://github.com/rails/rails/blob/c049f16ae3731eeff9753bd479c828cda1e82b49/actionpack/lib/action_controller/base.rb#L3)
* However, this is still a one way dependency, so still sensible that Action View could be used in isolation