### PR TITLE
Challenges 16 + 17: Extract ERB templates and use tag helpers

### DIFF
--- a/challenge_16/config.ru
+++ b/challenge_16/config.ru
@@ -1,0 +1,17 @@
+require_relative 'final_project'
+
+class LoggerMiddleware
+  def initialize(app, string)
+    @app = app
+    @string = string
+  end
+
+  def call(environment)
+    puts @string
+    @app.call(environment)
+  end
+end
+
+use LoggerMiddleware, 'Rack app got a request!'
+
+run MyApp.new

--- a/challenge_16/final_project.rb
+++ b/challenge_16/final_project.rb
@@ -26,8 +26,9 @@ end
 ActionController::Base.append_view_path('views')
 
 class AppController < ActionController::Base
-  # def root
-  # end
+  # We could actually omit this, and ActionController would still render our template :)
+  def root
+  end
 
   def show_data
     @blogs = Blog.all

--- a/challenge_16/final_project.rb
+++ b/challenge_16/final_project.rb
@@ -22,51 +22,26 @@ ActiveRecord::Schema.define do
   end
 end
 
+# Global configuration for view paths
+ActionController::Base.append_view_path('views')
+
 class AppController < ActionController::Base
-  def root
-    erb_response = <<~ERB
-      <p><strong>Submit a new Blog Post!</p></strong>
-      <form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>
-      <label>Blog Title: <input name='title'></label></p>
-      <p><label>Content: <textarea name='content'></textarea></label></p>
-      <p><button>Submit post</button></p>
-      </form>
-    ERB
-    render inline: erb_response
-  end
+  # def root
+  # end
 
   def show_data
     @blogs = Blog.all
-
-    # Note! ERB interpolated HTML is escaped unless marked as HTML safe / raw helper used
-
-    erb_response = <<~ERB
-      <ul>
-      <% @blogs.each do |blog| %>
-        <li>
-          <strong>Title: <%= blog.title %> </strong>, Content: <%= blog.content %>
-        </li>
-      <% end %>
-      </ul>
-    ERB
-    render inline: erb_response
   end
 
   def create_post
     puts 'Got a new POST request!'
-
-    # Blog.create!(title: params[:title], content: params[:content])
     Blog.create!(params.permit(:title, :content))
     redirect_to "/show-data", status: :see_other
   end
 
   def not_found
     @request_path = request.path_info
-
-    erb_response = <<~ERB
-      Sorry, I don’t know what <%= @request_path %> is 😢
-    ERB
-    render inline: erb_response, status: :not_found
+    render status: :not_found
   end
 end
 

--- a/challenge_16/final_project.rb
+++ b/challenge_16/final_project.rb
@@ -1,0 +1,93 @@
+### Require dependencies
+require 'action_controller'
+require 'action_dispatch'
+require 'active_record'
+
+class Blog < ActiveRecord::Base; end
+
+ActiveRecord::Base.establish_connection(
+  adapter:  "sqlite3",
+  database: "application.sqlite3"
+)
+
+# Create the table if it doesn't exist, seed some data
+ActiveRecord::Schema.define do
+  unless table_exists?(:blogs)
+    create_table :blogs do |t|
+      t.string :title
+      t.text :content
+    end
+    Blog.create!(title: 'My awesome blog!', content: 'my favourite HTML tags are <p> and <script>')
+    Blog.create!(title: 'Another cool blog!', content: 'my favourite HTML tags are <br> and <hr>')
+  end
+end
+
+class AppController < ActionController::Base
+  def root
+    erb_response = <<~ERB
+      <p><strong>Submit a new Blog Post!</p></strong>
+      <form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>
+      <label>Blog Title: <input name='title'></label></p>
+      <p><label>Content: <textarea name='content'></textarea></label></p>
+      <p><button>Submit post</button></p>
+      </form>
+    ERB
+    render inline: erb_response
+  end
+
+  def show_data
+    @blogs = Blog.all
+
+    # Note! ERB interpolated HTML is escaped unless marked as HTML safe / raw helper used
+
+    erb_response = <<~ERB
+      <ul>
+      <% @blogs.each do |blog| %>
+        <li>
+          <strong>Title: <%= blog.title %> </strong>, Content: <%= blog.content %>
+        </li>
+      <% end %>
+      </ul>
+    ERB
+    render inline: erb_response
+  end
+
+  def create_post
+    puts 'Got a new POST request!'
+
+    # Blog.create!(title: params[:title], content: params[:content])
+    Blog.create!(params.permit(:title, :content))
+    redirect_to "/show-data", status: :see_other
+  end
+
+  def not_found
+    @request_path = request.path_info
+
+    erb_response = <<~ERB
+      Sorry, I don’t know what <%= @request_path %> is 😢
+    ERB
+    render inline: erb_response, status: :not_found
+  end
+end
+
+class MyApp
+  def initialize
+    @router = ActionDispatch::Routing::RouteSet.new
+    draw_routes
+  end
+
+  def call(environment)
+    @router.call(environment)
+  end
+
+  private
+
+  def draw_routes
+    @router.draw do
+      root to: AppController.action(:root)
+      get '/show-data', to: AppController.action(:show_data)
+      post 'create-post', to: AppController.action(:create_post)
+      match '*path', via: :all, to: AppController.action(:not_found)
+    end
+  end
+end

--- a/challenge_16/views/app/not_found.html.erb
+++ b/challenge_16/views/app/not_found.html.erb
@@ -1,1 +1,3 @@
-Sorry, I don’t know what <%= @request_path %> is 😢
+<%= tag.p do %>
+  Sorry, I don’t know what <%= @request_path %> is 😢
+<% end %>

--- a/challenge_16/views/app/not_found.html.erb
+++ b/challenge_16/views/app/not_found.html.erb
@@ -1,0 +1,1 @@
+Sorry, I don’t know what <%= @request_path %> is 😢

--- a/challenge_16/views/app/root.html.erb
+++ b/challenge_16/views/app/root.html.erb
@@ -14,5 +14,7 @@
       Content: <%= text_area_tag "content" %>
     <% end %>
   <% end %>
-  <%= button_tag "Submit post" %>
+  <%# #button_tag is an alternative option here, but #submit_tag is preferred when we're not %>
+  <%# embedding rich content / other tags within the button %>
+  <%= submit_tag "Submit post" %>
 <% end %>

--- a/challenge_16/views/app/root.html.erb
+++ b/challenge_16/views/app/root.html.erb
@@ -1,6 +1,18 @@
-<p><strong>Submit a new Blog Post!</p></strong>
-<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>
-<label>Blog Title: <input name='title'></label></p>
-<p><label>Content: <textarea name='content'></textarea></label></p>
-<p><button>Submit post</button></p>
-</form>
+<%= tag.p do %>
+  <%= tag.strong do %>
+    Submit a new Blog Post!
+  <% end %>
+<% end %>
+<%= form_tag("/create-post") do %>
+  <%= tag.p do %>
+    <%= label_tag do %>
+      Blog Title: <%= text_field_tag "title" %>
+    <% end %>
+  <% end %>
+  <%= tag.p do %>
+    <%= label_tag do %>
+      Content: <%= text_area_tag "content" %>
+    <% end %>
+  <% end %>
+  <%= button_tag "Submit post" %>
+<% end %>

--- a/challenge_16/views/app/root.html.erb
+++ b/challenge_16/views/app/root.html.erb
@@ -1,0 +1,6 @@
+<p><strong>Submit a new Blog Post!</p></strong>
+<form method='post' enctype='application/x-www-form-urlencoded' action='/create-post'>
+<label>Blog Title: <input name='title'></label></p>
+<p><label>Content: <textarea name='content'></textarea></label></p>
+<p><button>Submit post</button></p>
+</form>

--- a/challenge_16/views/app/show_data.html.erb
+++ b/challenge_16/views/app/show_data.html.erb
@@ -1,7 +1,10 @@
-<ul>
-<% @blogs.each do |blog| %>
-  <li>
-    <strong>Title: <%= blog.title %> </strong>, Content: <%= blog.content %>
-  </li>
+<%= tag.ul do %>
+  <% @blogs.each do |blog| %>
+    <%= tag.li do %>
+      <%= tag.strong do %>
+        Title: <%= blog.title %>,
+      <% end %>
+      Content: <%= blog.content %>
+    <% end %>
+  <% end %>
 <% end %>
-</ul>

--- a/challenge_16/views/app/show_data.html.erb
+++ b/challenge_16/views/app/show_data.html.erb
@@ -1,9 +1,7 @@
 <%= tag.ul do %>
   <% @blogs.each do |blog| %>
     <%= tag.li do %>
-      <%= tag.strong do %>
-        Title: <%= blog.title %>,
-      <% end %>
+      <%= tag.strong do %>Title: <%= blog.title %><% end %>,
       Content: <%= blog.content %>
     <% end %>
   <% end %>

--- a/challenge_16/views/app/show_data.html.erb
+++ b/challenge_16/views/app/show_data.html.erb
@@ -1,0 +1,7 @@
+<ul>
+<% @blogs.each do |blog| %>
+  <li>
+    <strong>Title: <%= blog.title %> </strong>, Content: <%= blog.content %>
+  </li>
+<% end %>
+</ul>


### PR DESCRIPTION
Nothing too fancy in this PR! We've extracted the inline ERB into template files, and told `ActionController` where to find them using:
```ruby
ActionController::Base.append_view_path('views')
```
ActionController's [default rendering behaviour](https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-by-default-convention-over-configuration-in-action) is to look for a template in a directory that matches the controller name, with a filename that matches the action name.

So:
```ruby
class AppController < ActionController::Base
  def root
  end
```
will cause ActionController to look for `views/app/root.html.erb`.

💡 Fun Fact! You can omit an empty action method definition from a controller, and it ActionController will still render the associated template! (ie. we could omit `def root; end`). Rails ✨ magic ✨ 

We also introduced tag helpers, convenient ruby helper methods that build HTML compliant tags for us. While the simple ones like `tag.p` may not have a lot of added benefit in this case, the `form_tag` helper is a very useful helper because it handles many of the details for us, such as setting the default encoding type, defaulting to `/post` as the action, etc...