### PR TITLE
🚀 😱 🤯  FINAL CHALLENGE - Use URL helpers

### DIFF
--- a/last_challenge/final_project.rb
+++ b/last_challenge/final_project.rb
@@ -36,7 +36,7 @@ class BlogsController < ActionController::Base
   def create
     puts 'Got a new POST request!'
     Blog.create!(params.permit(:title, :content))
-    redirect_to "/blogs", status: :see_other
+    redirect_to blogs_url, status: :see_other
   end
 end
 
@@ -49,6 +49,7 @@ end
 
 # Top level entry point to Rack application is the RouteSet!
 MyApp = ActionDispatch::Routing::RouteSet.new
+BlogsController.include(MyApp.url_helpers)
 MyApp.draw do
   resources :blogs
   match '*path', via: :all, to: 'pages#not_found'

--- a/last_challenge/final_project.rb
+++ b/last_challenge/final_project.rb
@@ -36,7 +36,9 @@ class BlogsController < ActionController::Base
   def create
     puts 'Got a new POST request!'
     Blog.create!(params.permit(:title, :content))
-    redirect_to blogs_url, status: :see_other
+    # Since we're accessing the URL helpers right on the module, we need to specify
+    # both the host and port so that the full (absolute) URL can be constructed properly
+    redirect_to MyApp.url_helpers.blogs_url(host: request.host, port: request.port), status: :see_other
   end
 end
 
@@ -49,7 +51,10 @@ end
 
 # Top level entry point to Rack application is the RouteSet!
 MyApp = ActionDispatch::Routing::RouteSet.new
-BlogsController.include(MyApp.url_helpers)
+# Can mix the module with URL helpers right into the controller,
+# or access them as singleton methods on the module returned by
+# RouteSet#url_helpers
+# BlogsController.include(MyApp.url_helpers)
 MyApp.draw do
   resources :blogs
   match '*path', via: :all, to: 'pages#not_found'

--- a/last_challenge/views/blogs/new.html.erb
+++ b/last_challenge/views/blogs/new.html.erb
@@ -3,7 +3,7 @@
     Submit a new Blog Post!
   <% end %>
 <% end %>
-<%= form_tag("/blogs") do %>
+<%= form_tag(blogs_path) do %>
   <%= tag.p do %>
     <%= label_tag do %>
       Blog Title: <%= text_field_tag "title" %>

--- a/last_challenge/views/blogs/new.html.erb
+++ b/last_challenge/views/blogs/new.html.erb
@@ -3,7 +3,7 @@
     Submit a new Blog Post!
   <% end %>
 <% end %>
-<%= form_tag(blogs_path) do %>
+<%= form_tag(MyApp.url_helpers.blogs_path) do %>
   <%= tag.p do %>
     <%= label_tag do %>
       Blog Title: <%= text_field_tag "title" %>


### PR DESCRIPTION
In this PR, we introduce path / URL helpers made available to us via an (anonymous) module returned via [`ActionDispatch::Routing::RouteSet#url_helpers`](https://github.com/rails/rails/blob/v6.1.3/actionpack/lib/action_dispatch/routing/route_set.rb#L479-L485). All we have to do is include this module in our controller, ie. `BlogsController.include(MyApp.url_helpers)` and voila! We have access to these handy dandy helpers ✨ 

I had a couple questions @tomstuart !
1) In the doc, when you say
> We can either call the helper methods on this module object directly

Is this at all possible with our setup, or is the only way to access these helpers to include the module in the controller when we instantiate the `RouteSet`? Since we don't have a full Rails application I realize we can't do `Rails.application.routes.url_helpers`, but is there some other way for our views / controllers to access the routeset that you know of? 🤔 


2) I'm curious on the distinction between path and URL helpers. From the (light) research I did, many seemed to suggest that URL helpers are important if the URL will be consumed externally to the web app (ie. email) but also if a redirect is being used. For the latter, many claimed it to be because the HTTP specification indicates that an absolute URL is required for the `Location` header in any 3xx responses:
> For 3xx responses, the location SHOULD indicate the server's preferred URI for automatic redirection to the resource. The field value consists of a single absolute URI.
 Location       = "Location" ":" absoluteURI

According to https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30

However, the RFC we were originally looking at [says this:](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.2)

>      Location = URI-reference

> The field value consists of a single URI-reference.  When it has the
   form of a relative reference ([RFC3986], Section 4.2), the final
   value is computed by resolving it against the effective request URI
   ([RFC3986], Section 5).

>  If the Location value provided in a 3xx (Redirection) response does
   not have a fragment component, a user agent MUST process the
   redirection as if the value inherits the fragment component of the
   URI reference used to generate the request target (i.e., the
   redirection inherits the original reference's fragment, if any).

I'm kind of confused as to whether this is saying a different thing (that relative URLs are okay..?) and what the implications are for the redirect in our create action:
```ruby
  def create
    puts 'Got a new POST request!'
    Blog.create!(params.permit(:title, :content))
    redirect_to blogs_url, status: :see_other
  end
```

Can you offer any wisdom here? 😄 